### PR TITLE
Update requirements.txt, remove comfyui reqs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,4 @@
-torch
-torchvision
 diffusers>=0.27.0
 accelerate>=0.29.0
 numpy
 opencv-python
-Pillow
-pyyaml


### PR DESCRIPTION
ComfyUI already requires torch, torchvision, pyyaml, and Pillow...  ComfyUI-Manager started skipping torch in requirements text because it can screw up installs with weird versions of torch like nightlies (I've had it replace my local version with another one that broke CUDA and xformers recently, and less recently it could break torch-directml on Windows)...  If someone installs without manager using the requirements it just wastes time checking versions or potentially has the bad behavior, which can eat up a lot of time since torch is gigantic.  pyyaml and Pillow aren't nearly as big but since ComfyUI itself already requires them there's no point in duplicating it unless this works without Comfy (in which case there should probably be a secondary requirements text for standalone install)    ;-)  Cheers.