### PR TITLE
Fixed issue #49 upstream by cloning the model before patching it

### DIFF
--- a/brushnet_nodes.py
+++ b/brushnet_nodes.py
@@ -169,6 +169,10 @@ class BrushNet:
 
     def model_update(self, model, vae, image, mask, brushnet, positive, negative, scale, start_at, end_at):
 
+        # Make a copy of the model so that we're not patching it everywhere in
+        # the workflow.
+        model = model.clone()
+
         is_SDXL = False
         if isinstance(model.model.model_config, comfy.supported_models.SD15):
             print('Base model type: SD1.5')


### PR DESCRIPTION
I found that my workflow was generating the error message "BrushNet inference: there is no brushnet_model in transformer_options" in the console log because I had a second KSampler hooked up to the same model, but which didn't first pass through the BrushNet node. The BrushNet model patching code does not clone the model object, so any changes to the model are passed on to everywhere in your workflow.